### PR TITLE
allow 'finally' to be chained onto a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = {
     'promise/always-return': 'warn',
     'promise/no-return-wrap': 'warn',
     'promise/param-names': 'warn',
-    'promise/catch-or-return': 'warn',
+    'promise/catch-or-return': ['warn', {allowFinally: true}],
     'promise/no-native': 'off',
     'promise/no-nesting': 'warn',
     'promise/no-promise-in-callback': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-tree",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Shared Tree configuration that contains overrides and enhancements on top of the base frontier configuration.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Would allow us to add 'finally' to a promise chain without getting a bunch of lint warnings. 

## To-Dos
- [ ] Run tests (part of pre-push hook)
- [ ] Update demo and tests, if linting configuration is being changed
- [ ] Update documentation & README
- [x] Increment package.json version
