### PR TITLE
UpdateQALintingRules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-tree",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Shared Tree configuration that contains overrides and enhancements on top of the base frontier configuration.",
   "main": "index.js",
   "repository": {

--- a/qa.js
+++ b/qa.js
@@ -19,6 +19,7 @@ module.exports = {
         'testing-library/no-await-sync-query': 'off', // All @testing-library/webdriverio queries are async (https://testing-library.com/docs/webdriverio-testing-library/intro/)
         'testing-library/prefer-screen-queries': 'off', // We use browser instead of screen for @testing-library/webdriverio
         '@babel/no-unused-expressions': 'off' // to allow expressions like this: tree.expect(await (await $(tree.MBTpageObjects.getBCButton())).isDisplayed()).to.be.true
+        'func-names': 'off' // to allow for how WDIO does "it" functions: "it('Login', async function () {". We need "this" and we can keep "this" by using "unnamed async function"
       }
     }
   ]

--- a/qa.js
+++ b/qa.js
@@ -18,7 +18,7 @@ module.exports = {
         'import/no-extraneous-dependencies': ['error', { 'devDependencies': true }],
         'testing-library/no-await-sync-query': 'off', // All @testing-library/webdriverio queries are async (https://testing-library.com/docs/webdriverio-testing-library/intro/)
         'testing-library/prefer-screen-queries': 'off', // We use browser instead of screen for @testing-library/webdriverio
-        '@babel/no-unused-expressions': 'off' // to allow expressions like this: tree.expect(await (await $(tree.MBTpageObjects.getBCButton())).isDisplayed()).to.be.true
+        '@babel/no-unused-expressions': 'off', // to allow expressions like this: tree.expect(await (await $(tree.MBTpageObjects.getBCButton())).isDisplayed()).to.be.true
         'func-names': 'off' // to allow for how WDIO does "it" functions: "it('Login', async function () {". We need "this" and we can keep "this" by using "unnamed async function"
       }
     }


### PR DESCRIPTION
QA uses WDIO, and with some of the ways WDIO is formatted, we use unnamed functions as our `it` functions.
We CAN use arrow functions, but that kills the ability to use `this` in our tests. Which we use a lot.