### PR TITLE
Add cy files to our overrides for tests and non-production code to not include our extra rules that are not needed for that

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -123,6 +123,7 @@ module.exports = {
         'test-selectors/onKeyUp': 'off',
         'test-selectors/onSubmit': 'off',
         'import/prefer-default-export': 'off',
+        'promise/catch-or-return': 'off',
       },
     },
   ],

--- a/es6.js
+++ b/es6.js
@@ -98,7 +98,16 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.stories.*', '*test*', '**/test/**', '**/*mock*/**', '*mock*', '**/setupTests.*', '**/fixtures/**'],
+      files: [
+        '*.stories.*',
+        '*test*',
+        '**/test/**',
+        '**/*mock*/**',
+        '*mock*',
+        '**/setupTests.*',
+        '**/fixtures/**',
+        '**/*.cy.*',
+      ],
       rules: {
         'no-alert': 'off',
         'no-console': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-tree",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Shared Tree configuration that contains overrides and enhancements on top of the base frontier configuration.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
For example, we don't need to add test selectors for buttons in our cy tests.

This will make it so we don't see these warnings (and the like) in our apps that will have cypress testing:
![image](https://github.com/user-attachments/assets/02bc2b5c-be23-4695-8cb5-02242c2ff529)

![image](https://github.com/user-attachments/assets/f6aea969-7694-47c1-a481-44edbf5bbb62)


## To-Dos
- [x] Run tests (part of pre-push hook)
- [x] Update demo and tests, if linting configuration is being changed
- [ ] Update documentation & README
- [x] Increment package.json version
