### PR TITLE
Excluding import/extensions for qa. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-tree",
-  "version": "6.7.2",
+  "version": "6.7.3",
   "description": "Shared Tree configuration that contains overrides and enhancements on top of the base frontier configuration.",
   "main": "index.js",
   "repository": {

--- a/qa.js
+++ b/qa.js
@@ -22,6 +22,7 @@ module.exports = {
         'testing-library/prefer-screen-queries': 'off', // We use browser instead of screen for @testing-library/webdriverio
         '@babel/no-unused-expressions': 'off', // to allow expressions like this: tree.expect(await (await $(tree.MBTpageObjects.getBCButton())).isDisplayed()).to.be.true
         'func-names': 'off', // to allow for how WDIO does "it" functions: "it('Login', async function () {". We need "this" and we can keep "this" by using "unnamed async function"
+        'import/extensions': 'off', // Test directories use type: module, which for now requires extensions. This may stop being the case once everything we import is ESM.
       },
     },
   ],


### PR DESCRIPTION
We're already excluding this in individual repos, this just makes it global. Required for ES6 to interact with non-ES6 modules